### PR TITLE
Add basic endpoints that returns OK

### DIFF
--- a/src/main/kotlin/com/projconnectapi/plugins/Routing.kt
+++ b/src/main/kotlin/com/projconnectapi/plugins/Routing.kt
@@ -9,7 +9,7 @@ import io.ktor.request.*
 fun Application.configureRouting() {
 
     routing {
-        get("/") {
+        get("/status") {
             call.response.status(HttpStatusCode.OK)
         }
 


### PR DESCRIPTION
Adding endpoints `/post`, `/post/{id}`, `/user/{id}` and change endpoint
`/` to return just the OK signal.